### PR TITLE
TTF font rendering

### DIFF
--- a/NOLF/ClientShellDLL/ClientShellDLL.vcxproj
+++ b/NOLF/ClientShellDLL/ClientShellDLL.vcxproj
@@ -208,7 +208,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
       <MinimalRebuild>true</MinimalRebuild>
-      <AdditionalIncludeDirectories>..\shared;..\..\lt2\sdk\inc;..\..\lt2\lithshared\incs;..\ClientShellDLL;..\..\LIBS\SDL2-2.0.10\include;..\..\LIBS\detours\include;..\..\lt2\lithshared\lith;..\..\lt2\lithshared\ButeMgr\;..\..\lt2\lithshared\CryptMgr;..\..\lt2\lithshared\mfcstub;..\ClientRes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\shared;..\..\lt2\sdk\inc;..\..\lt2\lithshared\incs;..\ClientShellDLL;..\..\LIBS\SDL2-2.0.10\include;..\..\LIBS\detours\include;..\..\lt2\lithshared\lith;..\..\lt2\lithshared\ButeMgr\;..\..\lt2\lithshared\CryptMgr;..\..\lt2\lithshared\mfcstub;..\ClientRes;..\..\LIBS\SDL2_ttf-2.0.15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_CLIENTBUILD;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;NO_PRAGMA_LIBS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\Debug\</AssemblerListingLocation>
       <BrowseInformation>true</BrowseInformation>
@@ -254,10 +254,10 @@ call "D:\GameDev\no-one-lives-forever-master\NOLF\_after_build_debug.bat"</Comma
       <SubSystem>Windows</SubSystem>
       <OutputFile>debug\CShell.dll</OutputFile>
       <ImportLibrary>.\Debug\CShell.lib</ImportLibrary>
-      <AdditionalDependencies>odbc32.lib;odbccp32.lib;ButeMgr.lib;cryptmgr.lib;GameSpyClientMgr.lib;MFCStub.lib;StdLith.lib;RegMgr.lib;ltguimgr_LT2.lib;LithFontMgr_LT2.lib;SDL2.lib;SDL2main.lib;detours.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>odbc32.lib;odbccp32.lib;ButeMgr.lib;cryptmgr.lib;GameSpyClientMgr.lib;MFCStub.lib;StdLith.lib;RegMgr.lib;ltguimgr_LT2.lib;LithFontMgr_LT2.lib;SDL2.lib;SDL2main.lib;detours.lib;SDL2_ttf.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <IgnoreSpecificDefaultLibraries>libcimtd.lib;MSVCRTD.lib</IgnoreSpecificDefaultLibraries>
-      <AdditionalLibraryDirectories>..\..\lt2\lithshared\built\Debug\ButeMgr;..\..\lt2\lithshared\built\Debug\CryptMgr;..\..\lt2\lithshared\built\Debug\MFCStub;..\..\lt2\lithshared\libs\Debug;..\..\LIBS\SDL2-2.0.10\lib\x86;..\..\LIBS\detours\lib.X86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\lt2\lithshared\built\Debug\ButeMgr;..\..\lt2\lithshared\built\Debug\CryptMgr;..\..\lt2\lithshared\built\Debug\MFCStub;..\..\lt2\lithshared\libs\Debug;..\..\LIBS\SDL2-2.0.10\lib\x86;..\..\LIBS\detours\lib.X86;..\..\LIBS\SDL2_ttf-2.0.15\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Final Debug|Win32'">
@@ -431,6 +431,7 @@ call "D:\GameDev\no-one-lives-forever-master\NOLF\_after_build_debug.bat"</Comma
     <ClCompile Include="FolderViewInventory.cpp" />
     <ClCompile Include="FolderWeaponControls.cpp" />
     <ClCompile Include="FolderWeapons.cpp" />
+    <ClCompile Include="FontMgr.cpp" />
     <ClCompile Include="GameClientShell.cpp" />
     <ClCompile Include="GameSettings.cpp" />
     <ClCompile Include="GibFX.cpp" />
@@ -655,6 +656,7 @@ call "D:\GameDev\no-one-lives-forever-master\NOLF\_after_build_debug.bat"</Comma
     <ClInclude Include="FolderViewInventory.h" />
     <ClInclude Include="FolderWeaponControls.h" />
     <ClInclude Include="FolderWeapons.h" />
+    <ClInclude Include="FontMgr.h" />
     <ClInclude Include="GameButes.h" />
     <ClInclude Include="GameClientShell.h" />
     <ClInclude Include="GameSettings.h" />

--- a/NOLF/ClientShellDLL/ClientShellDLL.vcxproj.filters
+++ b/NOLF/ClientShellDLL/ClientShellDLL.vcxproj.filters
@@ -614,6 +614,9 @@
     <ClCompile Include="ConsoleMgr.cpp">
       <Filter>Source\Interface</Filter>
     </ClCompile>
+    <ClCompile Include="FontMgr.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Shared\AssertMgr.h">
@@ -1308,6 +1311,9 @@
     </ClInclude>
     <ClInclude Include="ConsoleMgr.h">
       <Filter>Source\Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="FontMgr.h">
+      <Filter>Headers</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/NOLF/ClientShellDLL/FontMgr.cpp
+++ b/NOLF/ClientShellDLL/FontMgr.cpp
@@ -80,7 +80,7 @@ void MakePCX(SDL_Surface* pSurface)
 	PCX.NumBitPlanes = 1;
 
 	// Start up a file
-	std::ofstream outFile("font.pcx", std::ios::binary | std::ios::out);
+	std::ofstream outFile("NOLF\\Modernizer\\Fonts\\font_large_0.pcx", std::ios::binary | std::ios::out);
 
 	//
 	// Header time!
@@ -126,7 +126,7 @@ void MakePCX(SDL_Surface* pSurface)
 		// FIXME: There's some over/under reading, not sure what the cause is, as my code is pretty close to the sample C code the spec has...
 		// So let's just write black!
 		if (y >= pSurface->h - 1) {
-			pixelBuffer = (unsigned char*)black->pixels;
+			pixelBuffer = (BYTE*)black->pixels;
 		}
 
 		BYTE pixel = pixelBuffer[y * pSurface->pitch];
@@ -234,9 +234,9 @@ bool FontMgr::Load(std::string font, int size)
 	SDL_Color bg = { 0,0,0 };
 	SDL_Surface* pSurface;
 	//TTF_SetFontKerning(pFont, 0);
-	if (!(pSurface = TTF_RenderText_Shaded(pFont, "!\"#$%&'()*+,-.0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]#_`abcdefghijklmnopqrstuvwxyz{|}~", color, bg))) {
+	//if (!(pSurface = TTF_RenderText_Shaded(pFont, "!\"#$%&'()*+,-.0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]#_`abcdefghijklmnopqrstuvwxyz{|}~", color, bg))) {
 		//handle error here, perhaps print TTF_GetError at least
-	}
+	//}
 	/*
 	else {
 		SDL_BlitSurface(text_surface, NULL, screen, NULL);
@@ -244,6 +244,40 @@ bool FontMgr::Load(std::string font, int size)
 		SDL_FreeSurface(text_surface);
 	}
 	*/
+
+
+	std::string sFontCharacters = "!\"#$%&'()*+,-.0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]#_`abcdefghijklmnopqrstuvwxyz{|}~";
+
+
+	// Create the initial file to cheat the width and height!
+	pSurface = TTF_RenderText_Shaded(pFont, sFontCharacters.c_str(), color, bg);
+	SDL_Rect rect = { 0, 0, pSurface->w, pSurface->h };
+	
+	// Ok fill it with black!
+	SDL_FillRect(pSurface, &rect, 0);
+
+	// X starts at 1, because we need one black space.
+	int x = 0;
+
+	// Ok let's loop through every character in our beautiful font alphabet
+	// We only want ONE PIXEL of space between characters.
+	for (auto gylph : sFontCharacters)
+	{
+		int minX, minY, maxX, maxY, advance;
+		TTF_GlyphMetrics(pFont, gylph, &minX, &maxX, &minY, &maxY, &advance);
+
+		int gylphWidth = maxX - minX;
+
+		SDL_Surface* pGylph = TTF_RenderGlyph_Shaded(pFont, gylph, color, bg);
+
+		rect = { x, 0, x + gylphWidth, 0 };
+		SDL_Rect srcRect = { minX, 0, maxX, pGylph->h };
+
+		SDL_BlitSurface(pGylph, &srcRect, pSurface, &rect);
+
+		// Advance our x position!
+		x += gylphWidth + 1;
+	}
 
 	/*
 	CxImage  image;

--- a/NOLF/ClientShellDLL/FontMgr.cpp
+++ b/NOLF/ClientShellDLL/FontMgr.cpp
@@ -1,0 +1,275 @@
+#include "stdafx.h"
+#include "FontMgr.h"
+#include "SDL.h"
+#include "SDL_ttf.h"
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+
+// Pretend this is a header for now!
+
+#define PCX_MAX_PALETTE 48
+// Thanks https://www.fileformat.info/format/pcx/egff.htm
+typedef struct _PcxHeader
+{
+	BYTE	Identifier;        /* PCX Id Number (Always 0x0A) */
+	BYTE	Version;           /* Version Number */
+	BYTE	Encoding;          /* Encoding Format */
+	BYTE	BitsPerPixel;      /* Bits per Pixel */
+	WORD	XStart;            /* Left of image */
+	WORD	YStart;            /* Top of Image */
+	WORD	XEnd;              /* Right of Image */
+	WORD	YEnd;              /* Bottom of image */
+	WORD	HorzRes;           /* Horizontal Resolution */
+	WORD	VertRes;           /* Vertical Resolution */
+	BYTE	Palette[PCX_MAX_PALETTE];       /* 16-Color EGA Palette */
+	BYTE	Reserved1;         /* Reserved (Always 0) */
+	BYTE	NumBitPlanes;      /* Number of Bit Planes */
+	WORD	BytesPerLine;      /* Bytes per Scan-line */
+	WORD	PaletteType;       /* Palette Type */
+	WORD	HorzScreenSize;    /* Horizontal Screen Size */
+	WORD	VertScreenSize;    /* Vertical Screen Size */
+	BYTE	Reserved2[54];     /* Reserved (Always 0) */
+} PCXHEAD;
+
+//
+// Returns the number of bytes written to data
+//
+int PCXEncodedPut(BYTE byte, int counter, std::ofstream* outFile)
+{
+	if (!counter) {
+		return 0;
+	}
+
+	if ( (counter == 1) && (0xC0 != (0xC0 & byte) ) )
+	{
+		outFile->write(reinterpret_cast<const char*>(&byte), sizeof(byte));
+		return 1;
+	}
+	unsigned char end = 0xC0 | counter;
+	outFile->write(reinterpret_cast<const char*>(&end), sizeof(end));
+	outFile->write(reinterpret_cast<const char*>(&byte), sizeof(byte));
+
+	return 2;
+}
+
+void MakePCX(SDL_Surface* pSurface)
+{	
+	BYTE colourMap[PCX_MAX_PALETTE] = { 0 };
+
+
+	int nImageSize = pSurface->pitch * pSurface->h;
+
+	_PcxHeader PCX;
+	memset(&PCX, 0, sizeof(PCX));
+
+	PCX.Identifier = 0x0A;
+	PCX.Version = 5;
+	PCX.Encoding = 1;
+	PCX.BitsPerPixel = 8;
+	PCX.XStart = 0;
+	PCX.XEnd = pSurface->w;
+	PCX.YStart = 0;
+	PCX.YEnd = pSurface->h;
+	memcpy(PCX.Palette , colourMap, sizeof(colourMap));
+	PCX.PaletteType = 1;
+	PCX.HorzRes = 96;
+	PCX.VertRes = 96;
+	PCX.BytesPerLine = pSurface->pitch;
+	PCX.NumBitPlanes = 1;
+
+	// Start up a file
+	std::ofstream outFile("font.pcx", std::ios::binary | std::ios::out);
+
+	//
+	// Header time!
+	//
+
+	// Write out the header, there's probably a better way to do this...
+	outFile.write(reinterpret_cast<const char*>(&PCX.Identifier), sizeof(PCX.Identifier));
+	outFile.write(reinterpret_cast<const char*>(&PCX.Version), sizeof(PCX.Version));
+	outFile.write(reinterpret_cast<const char*>(&PCX.Encoding), sizeof(PCX.Encoding));
+	outFile.write(reinterpret_cast<const char*>(&PCX.BitsPerPixel), sizeof(PCX.BitsPerPixel));
+	outFile.write(reinterpret_cast<const char*>(&PCX.XStart), sizeof(PCX.XStart));
+	outFile.write(reinterpret_cast<const char*>(&PCX.YStart), sizeof(PCX.YStart));
+	outFile.write(reinterpret_cast<const char*>(&PCX.XEnd), sizeof(PCX.XEnd));
+	outFile.write(reinterpret_cast<const char*>(&PCX.YEnd), sizeof(PCX.YEnd));
+	outFile.write(reinterpret_cast<const char*>(&PCX.HorzRes), sizeof(PCX.HorzRes));
+	outFile.write(reinterpret_cast<const char*>(&PCX.VertRes), sizeof(PCX.VertRes));
+	outFile.write(reinterpret_cast<const char*>(&PCX.Palette), sizeof(PCX.Palette));
+	outFile.write(reinterpret_cast<const char*>(&PCX.Reserved1), sizeof(PCX.Reserved1));
+	outFile.write(reinterpret_cast<const char*>(&PCX.NumBitPlanes), sizeof(PCX.NumBitPlanes));
+	outFile.write(reinterpret_cast<const char*>(&PCX.BytesPerLine), sizeof(PCX.BytesPerLine));
+	outFile.write(reinterpret_cast<const char*>(&PCX.PaletteType), sizeof(PCX.PaletteType));
+	outFile.write(reinterpret_cast<const char*>(&PCX.HorzScreenSize), sizeof(PCX.HorzScreenSize));
+	outFile.write(reinterpret_cast<const char*>(&PCX.VertScreenSize), sizeof(PCX.VertScreenSize));
+	outFile.write(reinterpret_cast<const char*>(&PCX.Reserved2), sizeof(PCX.Reserved2));
+	
+	//
+	// Encoding time!
+	// 
+
+	// Get a reference to the pixels, and setup our last and current pixel
+	BYTE* pixelBuffer = (BYTE*)pSurface->pixels;
+
+	// Used to cover a weird bug, see the FIXME below!
+	SDL_Surface* black = SDL_CreateRGBSurface(0, pSurface->w, pSurface->h, 8, 0, 0, 0, 0);
+	SDL_Rect rect = { 0, 0, pSurface->w, pSurface->h + 8 };
+	SDL_FillRect(black, &rect, 0);
+
+	for (int y = 0; y < pSurface->h + 1; y++)
+	{
+		int counter = 1;
+		int total = 0;
+
+		// FIXME: There's some over/under reading, not sure what the cause is, as my code is pretty close to the sample C code the spec has...
+		// So let's just write black!
+		if (y >= pSurface->h - 1) {
+			pixelBuffer = (unsigned char*)black->pixels;
+		}
+
+		BYTE pixel = pixelBuffer[y * pSurface->pitch];
+		BYTE lastPixel = pixel;
+
+		// This will run through every pixel of the image, and encode it with RLE.
+		for (int x = 1; x < pSurface->pitch; x++)
+		{
+			// Increment our pixel
+			pixel = pixelBuffer[(y * pSurface->pitch) + x];
+
+			if (pixel == lastPixel) {
+				counter++;
+				// We hit our max, write!
+				if (counter == 63)
+				{
+					int i = PCXEncodedPut(lastPixel, counter, &outFile);
+					total += i;
+					counter = 0;
+				}
+			}
+			else
+			{
+				if (counter)
+				{
+					int i = PCXEncodedPut(lastPixel, counter, &outFile);
+					total += i;
+				}
+
+				lastPixel = pixel;
+				counter = 1;
+			}
+		}
+		if (counter) {
+			int i = PCXEncodedPut(lastPixel, counter, &outFile);
+			total += i;
+		}
+	}
+
+	// Clean up the bugfix surface
+	SDL_FreeSurface(black);
+
+	//
+	// Palette time, mark a palette, and write out SDL2's one!
+	// 
+
+	int paletteIdentifier = 0x0C;
+	outFile.write(reinterpret_cast<const char*>(&paletteIdentifier), sizeof(paletteIdentifier));
+
+	SDL_Color* sdlPal = pSurface->format->palette->colors;
+	BYTE pal[768] = { 0 };
+	for (int i = 0; i < 256; i++) {
+		pal[3 * i] =	 sdlPal[i].r;
+		pal[3 * i + 1] = sdlPal[i].g;
+		pal[3 * i + 2] = sdlPal[i].b;
+	}
+	outFile.write(reinterpret_cast<const char*>(&pal), 768);
+
+	// We're done folks!
+	outFile.close();
+
+}
+
+
+FontMgr* g_pFontMgr = NULL;
+
+FontMgr::FontMgr()
+{
+	g_pFontMgr = this;
+}
+
+FontMgr::~FontMgr()
+{
+	Term();
+}
+
+bool FontMgr::Init()
+{
+	if (TTF_Init() == -1) {
+		g_pLTClient->CPrint("TTF_Init: %s\n", TTF_GetError());
+		ASSERT(LTFALSE);
+		return false;
+	}
+
+	return true;
+}
+
+bool FontMgr::Term()
+{
+	return true;
+}
+
+bool FontMgr::Load(std::string font, int size)
+{
+	// load font.ttf at size 16 into font
+	TTF_Font* pFont;
+	pFont = TTF_OpenFont(font.c_str(), size);
+	if (!pFont) {
+		g_pLTClient->CPrint("TTF_OpenFont: %s\n", TTF_GetError());
+		return false;
+	}
+
+	//SDL_Surface* pSurface = NULL;
+	SDL_Color color = { 255,255,255 };
+	SDL_Color bg = { 0,0,0 };
+	SDL_Surface* pSurface;
+	//TTF_SetFontKerning(pFont, 0);
+	if (!(pSurface = TTF_RenderText_Shaded(pFont, "!\"#$%&'()*+,-.0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]#_`abcdefghijklmnopqrstuvwxyz{|}~", color, bg))) {
+		//handle error here, perhaps print TTF_GetError at least
+	}
+	/*
+	else {
+		SDL_BlitSurface(text_surface, NULL, screen, NULL);
+		//perhaps we can reuse it, but I assume not for simplicity.
+		SDL_FreeSurface(text_surface);
+	}
+	*/
+
+	/*
+	CxImage  image;
+// bmp -> jpg
+
+
+image.Load("image.bmp", CXIMAGE_FORMAT_BMP);
+if (image.IsValid()){
+    if(!image.IsGrayScale()) image.IncreaseBpp(24);
+    image.SetJpegQuality(80);
+    image.Save("image.jpg",CXIMAGE_FORMAT_JPG);
+}
+// png -> tif
+
+
+image.Load("image.png", CXIMAGE_FORMAT_PNG);
+if (image.IsValid()){
+    image.Save("image.tif",CXIMAGE_FORMAT_TIF);
+}*/
+
+	MakePCX(pSurface);
+
+
+	SDL_SaveBMP(pSurface, "font.bmp");
+	SDL_FreeSurface(pSurface);
+
+}
+
+

--- a/NOLF/ClientShellDLL/FontMgr.h
+++ b/NOLF/ClientShellDLL/FontMgr.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <string>
+
+class FontMgr
+{
+public:
+	FontMgr();
+	~FontMgr();
+
+	bool Init();
+	bool Term();
+
+	bool Load(std::string font, int size);
+
+};
+

--- a/NOLF/ClientShellDLL/GameClientShell.cpp
+++ b/NOLF/ClientShellDLL/GameClientShell.cpp
@@ -57,6 +57,7 @@
 #include <SDL.h>
 #include "ConsoleMgr.h"
 #include "DetourMgr.h"
+#include "FontMgr.h"
 
 extern ConsoleMgr* g_pConsoleMgr;
 
@@ -1441,6 +1442,10 @@ uint32 CGameClientShell::OnEngineInitialized(RMode *pMode, LTGUID *pAppGuid)
 
 	DetourMgr* detourMgr = new DetourMgr();
 	detourMgr->Init();
+
+	FontMgr* pFontMgr = new FontMgr();
+	pFontMgr->Init();
+	pFontMgr->Load("Fonts\\KIMBERLE.TTF", 32);
 
 
 	return LT_OK;
@@ -3800,13 +3805,13 @@ void CGameClientShell::UpdateContainerFX()
 		if (IsLiquid(m_eCurContainerCode) && !IsLiquid(eCode))
 		{
             UpdateUnderWaterFX(LTFALSE);
-            g_pLTClient->RunConsoleString("+ModelWarble 0");
+            //g_pLTClient->RunConsoleString("+ModelWarble 0");
 			m_InterfaceMgr.EndUnderwater();
 		}
 
 		if (!IsLiquid(m_eCurContainerCode) && IsLiquid(eCode))
 		{
-            g_pLTClient->RunConsoleString("ModelWarble 1");
+            //g_pLTClient->RunConsoleString("ModelWarble 1");
 			m_InterfaceMgr.BeginUnderwater();
 		}
 

--- a/NOLF/ClientShellDLL/GameClientShell.cpp
+++ b/NOLF/ClientShellDLL/GameClientShell.cpp
@@ -1218,6 +1218,11 @@ uint32 CGameClientShell::OnEngineInitialized(RMode *pMode, LTGUID *pAppGuid)
 
 	// Interface stuff...
 
+	// Init font stuff here!
+	FontMgr* pFontMgr = new FontMgr();
+	pFontMgr->Init();
+	pFontMgr->Load("Fonts\\KIMBERLE.TTF", 32);
+
 	if (!m_InterfaceMgr.Init())
 	{
 		// Don't call ShutdownWithMessage since InterfaceMgr will have called
@@ -1443,10 +1448,11 @@ uint32 CGameClientShell::OnEngineInitialized(RMode *pMode, LTGUID *pAppGuid)
 	DetourMgr* detourMgr = new DetourMgr();
 	detourMgr->Init();
 
+	/*
 	FontMgr* pFontMgr = new FontMgr();
 	pFontMgr->Init();
 	pFontMgr->Load("Fonts\\KIMBERLE.TTF", 32);
-
+	*/
 
 	return LT_OK;
 }

--- a/NOLF/ClientShellDLL/InterfaceResMgr.cpp
+++ b/NOLF/ClientShellDLL/InterfaceResMgr.cpp
@@ -116,6 +116,8 @@ LTBOOL CInterfaceResMgr::Init(ILTClient* pClientDE, CGameClientShell* pClientShe
 	// set resolution dependant variables
 	ScreenDimsChanged();
 
+	// font mgr here plz
+
 
 	// Initialize the fonts
     if (!InitFonts())
@@ -458,6 +460,7 @@ LTBOOL CInterfaceResMgr::InitFonts()
 
         // *********** medium font
 		g_pLayoutMgr->GetMediumFontBase(g_szFontName,sizeof(g_szFontName));
+		//LTStrCpy(g_szFontName, "..\\NOLF\\modernizer\\fonts\\font_med_0.pcx", sizeof(g_szFontName));
         if (!SetupFont(m_pMediumFont))
 		{
 			debug_delete(m_pMediumFont);
@@ -466,7 +469,8 @@ LTBOOL CInterfaceResMgr::InitFonts()
 		}
 
         // *********** Large font
-		g_pLayoutMgr->GetLargeFontBase(g_szFontName,sizeof(g_szFontName));
+		//g_pLayoutMgr->GetLargeFontBase(g_szFontName,sizeof(g_szFontName));
+		LTStrCpy(g_szFontName, "..\\NOLF\\modernizer\\fonts\\font_large_0.pcx", sizeof(g_szFontName));
         if (!SetupFont(m_pLargeFont))
 		{
 			debug_delete(m_pLargeFont);

--- a/NOLF/ClientShellDLL/InterfaceResMgr.cpp
+++ b/NOLF/ClientShellDLL/InterfaceResMgr.cpp
@@ -9,10 +9,12 @@
 #include "ClientButeMgr.h"
 #include "SDL.h"
 #include "ConsoleMgr.h"
+#include "FontMgr.h"
 
 CInterfaceResMgr*   g_pInterfaceResMgr = LTNULL;
 extern SDL_Window* g_SDLWindow;
 extern ConsoleMgr* g_pConsoleMgr;
+extern FontMgr* g_pFontMgr;
 
 namespace
 {
@@ -863,6 +865,39 @@ HSURFACE CInterfaceResMgr::CreateSurfaceFromString(CLTGUIFont *pFont, char *lpsz
 
 
 
+#if 1
+LTBOOL CInterfaceResMgr::SetupFont(CLTGUIFont* pFont, LTBOOL bBlend, uint32 dwFlags)
+{
+
+	LITHFONTCREATESTRUCT lithFont;
+	lithFont.szFontBitmap = g_szFontName;
+	lithFont.nGroupFlags = dwFlags;
+	if (bBlend)
+	{
+		lithFont.bChromaKey = LTFALSE;
+		lithFont.hTransColor = kBlack;
+	}
+	else
+	{
+		lithFont.bChromaKey = LTTRUE;
+		lithFont.hTransColor = SETRGB(255, 0, 255);
+	}
+
+	if (!pFont->Init(g_pLTClient, &lithFont))
+	{
+		char szString[512];
+		sprintf(szString, "Cannot load font: %s", lithFont.szFontBitmap);
+		g_pLTClient->CPrint(szString);
+		SDL_Log(szString);
+		return LTFALSE;
+	}
+
+
+	SDL_Log("Initialized %s", lithFont.szFontBitmap);
+
+	return LTTRUE;
+}
+#else
 LTBOOL CInterfaceResMgr::SetupFont(CLTGUIFont *pFont, LTBOOL bBlend, uint32 dwFlags)
 {
 
@@ -894,6 +929,7 @@ LTBOOL CInterfaceResMgr::SetupFont(CLTGUIFont *pFont, LTBOOL bBlend, uint32 dwFl
 
     return LTTRUE;
 }
+#endif
 
 CLTGUIFont* CInterfaceResMgr::GetLargeFont()
 {

--- a/osslicenses.txt
+++ b/osslicenses.txt
@@ -16,3 +16,68 @@ freely, subject to the following restrictions:
 2. Altered source versions must be plainly marked as such, and must not be
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
+--
+SDL TTF https://www.libsdl.org/projects/SDL_ttf/
+/*
+  SDL_ttf:  A companion library to SDL for working with TrueType (tm) fonts
+  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+--
+CXImage http://www.xdp.it/cximage/
+--------------------------------------------------------------------------------
+
+COPYRIGHT NOTICE, DISCLAIMER, and LICENSE:
+
+CxImage version 7.0.1 07/Jan/2011
+
+CxImage : Copyright (C) 2001 - 2011, Davide Pizzolato
+
+Original CImage and CImageIterator implementation are:
+Copyright (C) 1995, Alejandro Aguilar Sierra (asierra(at)servidor(dot)unam(dot)mx)
+
+Covered code is provided under this license on an "as is" basis, without warranty
+of any kind, either expressed or implied, including, without limitation, warranties
+that the covered code is free of defects, merchantable, fit for a particular purpose
+or non-infringing. The entire risk as to the quality and performance of the covered
+code is with you. Should any covered code prove defective in any respect, you (not
+the initial developer or any other contributor) assume the cost of any necessary
+servicing, repair or correction. This disclaimer of warranty constitutes an essential
+part of this license. No use of any covered code is authorized hereunder except under
+this disclaimer.
+
+Permission is hereby granted to use, copy, modify, and distribute this
+source code, or portions hereof, for any purpose, including commercial applications,
+freely and without fee, subject to the following restrictions: 
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+--------------------------------------------------------------------------------
+
+Other information: about CxImage, and the latest version, can be found at the
+CxImage home page: http://www.xdp.it
+
+--------------------------------------------------------------------------------


### PR DESCRIPTION
(WIP)
This PR adds TTF font rendering!..well not really, but kinda! 

So while this version of the engine can load TTF fonts, it's limited to system fonts and the actual rendering is incredibly slow. 

So what I do to get around this is use a library (SDL TTF) to load custom TTF fonts, format them correctly (the engine expects only a single space in between characters. Which is a huge pain, because fonts like to lie about their glyph width.) export the font sheet to PCX format (the engine only supports PCX for bitmap fonts.) in a encoder I wrote (because there weren't any good small portable ones.) and then immediately load that pcx. 

And bam, we have variable size font rendering! 50% of this PR could be avoided if we could create a font from an array of pixels, but we can't. 

---
There's still bug in the glyph rendering. I need to properly take into account the minX and maxX. Right now I'm trimming the start of the character to get the real minX, but some fonts can be cut off on the maxX portion. 

Square 721 (included in NOLF2)
![image](https://user-images.githubusercontent.com/3683240/72238385-6db07680-3592-11ea-9d4d-492806067d74.png)

Comic Sans (yay)
![image](https://user-images.githubusercontent.com/3683240/72238515-cd0e8680-3592-11ea-88d7-0679b7a0e1e0.png)
